### PR TITLE
Fix load_dotenv

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,8 +2,7 @@
 @author: sta
 """
 
-
-from utils.configuration import conf
+from utils.configuration import Configuration
 from utils.logger import logger
 from utils.gcp import stream_download_upload
 from utils.data_sources import data_sources
@@ -13,8 +12,8 @@ bucket_name = "effidic-open-data"
 for data_source in data_sources:
     logger.info(f"Traitement de la Data_source : {data_source}")
     stream_download_upload(
-        bucket_name= conf.GCP_BUCKET_NAME,
+        bucket_name=Configuration.GCP_BUCKET_NAME,
         destination_blob_name=data_source.destination_blob_name,
-        source_url = data_source.url
+        source_url=data_source.url,
     )
 logger.info("job etl terminé")

--- a/src/utils/configuration.py
+++ b/src/utils/configuration.py
@@ -1,9 +1,13 @@
 """
 @author: sta
 """
+
 import os
 
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
+
+# Le chargement du dotenv doit ce faire avant la creation de la classe.
+load_dotenv(dotenv_path=find_dotenv(), override=True)
 
 
 class Configuration:
@@ -20,6 +24,3 @@ class Configuration:
     KEYFILE_PRIVATE_KEY = os.environ.get("KEYFILE_PRIVATE_KEY")
     KEYFILE_PRIVATE_KEY_ID = os.environ.get("KEYFILE_PRIVATE_KEY_ID")
     GCP_BUCKET_NAME = os.environ.get("GCP_BUCKET_NAME")
-
-load_dotenv(override=True)
-conf = Configuration()


### PR DESCRIPTION
Le chargement du dotenv doit ce faire avant la création de la classe pour que les variables "static" de la classe Configuration soient bien chargées.
